### PR TITLE
Archive VUM and delete CUA repo

### DIFF
--- a/otterdog/eclipse-leda.jsonnet
+++ b/otterdog/eclipse-leda.jsonnet
@@ -63,12 +63,6 @@ orgs.newOrg('eclipse-leda') {
       description: "SDV Cloud Connector for Azure IoT Hub",
       web_commit_signoff_required: false,
     },
-    orgs.newRepo('leda-contrib-container-update-agent') {
-      allow_merge_commit: true,
-      allow_update_branch: false,
-      delete_branch_on_merge: false,
-      web_commit_signoff_required: false,
-    },
     orgs.newRepo('leda-contrib-otel') {
       allow_merge_commit: true,
       allow_update_branch: false,
@@ -93,6 +87,7 @@ orgs.newOrg('eclipse-leda') {
     orgs.newRepo('leda-contrib-vehicle-update-manager') {
       allow_merge_commit: true,
       allow_update_branch: false,
+      archived: true,
       delete_branch_on_merge: false,
       description: "Vehicle Update Manager (VUM)",
       web_commit_signoff_required: false,


### PR DESCRIPTION
VUM is now part of Eclipse Kanto, archive the old repo since it still contains source code, and delete CUA repo (empty, part of kanto now)